### PR TITLE
Implement character trimming

### DIFF
--- a/R/parsers.R
+++ b/R/parsers.R
@@ -19,7 +19,7 @@ NULL
 #' @param trim If \code{TRUE}, will trim off any leading or trailing whitespace.
 #' @rdname parser
 #' @export
-character_parser <- function(trim = FALSE) {
+character_parser <- function(trim = TRUE) {
   parser("character", trim = trim)
 }
 

--- a/R/parsers.R
+++ b/R/parsers.R
@@ -8,7 +8,7 @@ print.parser <- function(x, ...) {
 }
 
 find_parser <- function(name) {
-  match.fun(paste0(name, "_parser"))()
+  get(paste0(name, "_parser"), envir = asNamespace("fastread"))()
 }
 
 #' Define how to parse each column

--- a/inst/include/fastread/Source.h
+++ b/inst/include/fastread/Source.h
@@ -43,7 +43,7 @@ namespace fastread {
             return res ;
         }
 
-        SEXP get_String(){
+        SEXP get_String(bool trim = true){
             char* q = p ;
             int len = move_until_next_token_start() ;
 
@@ -56,6 +56,18 @@ namespace fastread {
             // skip end quote
             if( q[len-1] == quote ){
                 len-- ;
+            }
+
+            // trim leading and trailing whitespaces
+            if (trim)
+            {
+              if (*q == ' ')
+              {
+                len--;
+                q++;
+              }
+              if (q[len-1] == ' ')
+                len--;
             }
 
             // check if there are double quotes

--- a/inst/include/fastread/Source.h
+++ b/inst/include/fastread/Source.h
@@ -59,10 +59,8 @@ namespace fastread {
             }
 
             // trim leading and trailing whitespaces
-            if (trim)
-            {
-              if (*q == ' ')
-              {
+            if (trim) {
+              if (*q == ' ') {
                 len--;
                 q++;
               }
@@ -215,9 +213,7 @@ namespace fastread {
             // valid digit, then the function returns 0, which is not a
             // nice way to handle NA
             if (!valid_digit())
-            {
               return -1;
-            }
 
             // Get digits before decimal point or exponent, if any.
             for (value = 0; valid_digit(); ++p ) {

--- a/inst/include/fastread/Source.h
+++ b/inst/include/fastread/Source.h
@@ -211,6 +211,14 @@ namespace fastread {
                 ++p ;
             }
 
+            // Exception needed because if the first character is not a
+            // valid digit, then the function returns 0, which is not a
+            // nice way to handle NA
+            if (!valid_digit())
+            {
+              return -1;
+            }
+
             // Get digits before decimal point or exponent, if any.
             for (value = 0; valid_digit(); ++p ) {
                 value = value * 10 + digit_value() ;

--- a/inst/include/fastread/Source.h
+++ b/inst/include/fastread/Source.h
@@ -147,7 +147,16 @@ namespace fastread {
                 p = end ;
                 if( !more() ) break ;
             }
-            return n ;
+
+            // get pointer to antepenultimate (before last) character
+            p -= 2;
+
+            // increment the number of lines by one if antepenultimate
+            // character is not positioned on a full line
+            return n + (int)(!ensure_full_line());
+
+            // TODO: Might need to do the same trick in the function below
+            // I still have not figured out when it is supposed to be used
         }
 
         // for each line, we need to ask to the line policy if we keep the line

--- a/inst/include/fastread/VectorInput.h
+++ b/inst/include/fastread/VectorInput.h
@@ -104,8 +104,13 @@ namespace fastread {
     class VectorInput_String : public VectorInput<Source> {
     public:
         typedef VectorInput<Source> Base ;
-        VectorInput_String( int n, Source* source_ ) :
-            Base(source_), data(no_init(n) ){}
+        VectorInput_String( int n, Source* source_, bool trim_ ) :
+            Base(source_),
+            data(no_init(n)),
+            trim(trim_)
+            {
+
+            }
         void set( int i ) {
             data[i] = Base::source->get_String() ;
         }
@@ -113,6 +118,7 @@ namespace fastread {
 
     private:
         CharacterVector data ;
+        bool trim;
     } ;
 
     template <typename Source>
@@ -202,7 +208,10 @@ namespace fastread {
 
       if( clazz == "integer"   ) return new VectorInput_Integer<Source>(n, &source) ;
       if( clazz == "double"    ) return new VectorInput_Double<Source>(n, &source) ;
-      if( clazz == "character" ) return new VectorInput_String<Source>(n, &source) ;
+      if( clazz == "character" ) {
+        bool trim = as<LogicalVector>(spec["trim"]);
+        return new VectorInput_String<Source>(n, &source, trim) ;
+      }
       if( clazz == "skip"      ) return new VectorInput_Skip<Source>(n, &source) ;
       if( clazz == "factor"    ) {
         CharacterVector levels = as<CharacterVector>(spec["levels"]);

--- a/inst/include/fastread/VectorInput.h
+++ b/inst/include/fastread/VectorInput.h
@@ -105,12 +105,7 @@ namespace fastread {
     public:
         typedef VectorInput<Source> Base ;
         VectorInput_String( int n, Source* source_, bool trim_ ) :
-            Base(source_),
-            data(no_init(n)),
-            trim(trim_)
-            {
-
-            }
+            Base(source_), data(no_init(n)), trim(trim_) {}
         void set( int i ) {
             data[i] = Base::source->get_String() ;
         }

--- a/inst/include/fastread/get_int_naive.h
+++ b/inst/include/fastread/get_int_naive.h
@@ -1,22 +1,25 @@
 #ifndef FASTREAD_get_int_naive_H
 #define FASTREAD_get_int_naive_H
 
+// TO DO: Is it a duplicate with respect to the get_int_naive
+// function declared in Source.h ?
+
 namespace fastread {
-    
+
     inline bool valid_digit(char c){
         static char before_zero = '0' - 1 ;
         static char after_nine = '9' + 1 ;
         return c > before_zero && c < after_nine ;
     }
-    
+
     inline int get_int_naive(char*& p) {
         int sign, value ;
-    
+
         // Skip leading white space, if any.
         while ( *p == ' ' ) {
             ++p ;
         }
-    
+
         // Get sign, if any.
         sign = 1;
         if (*p == '-') {
@@ -25,15 +28,23 @@ namespace fastread {
         } else if (*p == '+') {
             ++p ;
         }
-    
+
+        // Exception needed because if the first character is not a
+        // valid digit, then the function returns 0, which is not a
+        // nice way to handle NA
+        if (!valid_digit(*p))
+        {
+          return -1;
+        }
+
         // Get digits before decimal point or exponent, if any.
         for (value = 0; valid_digit(*p); ++p ) {
             value = value * 10 + (*p - '0');
         }
-    
+
         return sign * value ;
     }
-    
+
 }
 
 #endif

--- a/inst/include/fastread/get_int_naive.h
+++ b/inst/include/fastread/get_int_naive.h
@@ -33,9 +33,7 @@ namespace fastread {
         // valid digit, then the function returns 0, which is not a
         // nice way to handle NA
         if (!valid_digit(*p))
-        {
           return -1;
-        }
 
         // Get digits before decimal point or exponent, if any.
         for (value = 0; valid_digit(*p); ++p ) {


### PR DESCRIPTION
Main:
* Trimming was optional in character_parser() but actually not implemented.

Additionally:
* change integer parsing from 0 to -1 for unrecognised integers;
* count lines correctly if last line of file has no '\n' line break, which happens to some CSV files.